### PR TITLE
add go mod vendor in order to rebuild the docker image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GO111MODULE=on \
 
 WORKDIR /go/src/app
 COPY . .
-
+RUN go mod vendor
 RUN go build \
   -a \
   -ldflags "-s -w -extldflags 'static'" \


### PR DESCRIPTION
> when I try to build this image to push into a private registry get this errors:

docker build . 
Sending build context to Docker daemon  44.03kB
Step 1/9 : FROM golang:1.13 AS builder
1.13: Pulling from library/golang
90fe46dd8199: Pull complete
35a4f1977689: Pull complete
bbc37f14aded: Pull complete
74e27dc593d4: Pull complete
38b1453721cb: Pull complete
fbf24695ef98: Pull complete
4780acafd98c: Pull complete
Digest: sha256:a90f2671330831830e229c3554ce118009681ef88af659cd98bfafd13d5594f9
Status: Downloaded newer image for golang:1.13
 ---> 7ec6e7161786
Step 2/9 : ENV GO111MODULE=on   CGO_ENABLED=0   GOOS=linux   GOARCH=amd64
 ---> Running in 559fa2746f26
Removing intermediate container 559fa2746f26
 ---> e2e0ddef6ee7
Step 3/9 : WORKDIR /go/src/app
 ---> Running in c4ab78e4db34
Removing intermediate container c4ab78e4db34
 ---> d227b21573c6
Step 4/9 : COPY . .
 ---> 114bfa37f435
Step 5/9 : RUN go build   -a   -ldflags "-s -w -extldflags 'static'"   -installsuffix cgo   -tags netgo   -mod vendor   -o /bin/vault-init   .
 ---> Running in c8098fab3807
build github.com/sethvargo/vault-init: cannot load cloud.google.com/go/storage: open /go/src/app/vendor/cloud.google.com/go/storage: no such file or directory
The command '/bin/sh -c go build   -a   -ldflags "-s -w -extldflags 'static'"   -installsuffix cgo   -tags netgo   -mod vendor   -o /bin/vault-init   .' returned a non-zero code: 1