### PR TITLE
Fix image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this as part of a Kubernetes Vault Deployment:
 ```yaml
 containers:
 - name: vault-init
-  image: registry.hub.docker.com/sethvargo/vault-init:1.1.2
+  image: registry.hub.docker.com/sethvargo/vault-init:0.1.2
   imagePullPolicy: Always
   env:
   - name: GCS_BUCKET_NAME


### PR DESCRIPTION
In the readme the image tag is 1.1.2, but that doesn't exists. The correct would be 0.1.2.