### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ containers:
 
 ## Configuration
 
-The vault-init service supports the following environment variables for configuration:
+The `vault-init` service supports the following environment variables for configuration:
 
 - `CHECK_INTERVAL` ("10s") - The time duration between Vault health checks. Set
   this to a negative number to unseal once and exit.
 
-- `GCS_BUCKET_NAME` - The Google Cloud Storage Bucket where the vault master key
+- `GCS_BUCKET_NAME` - The Google Cloud Storage Bucket where the Vault master key
   and root token is stored.
 
 - `KMS_KEY_ID` - The Google Cloud KMS key ID used to encrypt and decrypt the
@@ -47,7 +47,7 @@ The vault-init service supports the following environment variables for configur
 
 - `VAULT_SECRET_THRESHOLD` (3) - The number of human shares required to unseal.
 
-- `VAULT_AUTO_UNSEAL` - Use Vault 1.0 native auto-unsealing directly. You must
+- `VAULT_AUTO_UNSEAL` (true) - Use Vault 1.0 native auto-unsealing directly. You must
   set the seal configuration in Vault's configuration.
 
 - `VAULT_STORED_SHARES` (1) - Number of shares to store on KMS. Only applies to
@@ -56,7 +56,7 @@ The vault-init service supports the following environment variables for configur
 - `VAULT_RECOVERY_SHARES` (1) - Number of recovery shares to generate. Only
   applies to Vault 1.0 native auto-unseal.
 
-- `VAULT_RECOVERY_THRESHOLD` (1) - Number of recovery shares needed to unseal.
+- `VAULT_RECOVERY_THRESHOLD` (1) - Number of recovery shares needed to trigger an auto-unseal.
   Only applies to Vault 1.0 native auto-unseal.
 
 - `VAULT_SKIP_VERIFY` (false) - Disable TLS validation when connecting. Setting


### PR DESCRIPTION
Hey @sethvargo,

while I was reading the `vault-init` README and the Vault docs, I found a potential misleading phrasing in the part related to `VAULT_RECOVERY_THRESHOLD`: as far as I understood, recovery keys are not enough to unseal Vault, but they can be used to trigger an auto-unseal when, for example, a Vault instance (with auto-unseal configured) is manually sealed.

With this README update, I just wanted to make it more clear that the recovery keys can't be used to unseal Vault if the auto-unsealing mechanism is not working.

Thanks!

Refs:
- https://www.vaultproject.io/docs/commands/operator/init#hsm-and-kms-options
- https://www.vaultproject.io/docs/concepts/seal#auto-unseal