### PR TITLE
adding environment variables for storage objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ The `vault-init` service supports the following environment variables for config
 - `GCS_BUCKET_NAME` - The Google Cloud Storage Bucket where the Vault master key
   and root token is stored.
 
+- `GCS_ROOT_TOKEN_OBJECT` ("root-token.enc") - The name of the storage object to create containing the vault root token in the storage bucket specified by `GCS_BUCKET_NAME`
+
+- `GCS_UNSEAL_KEYS_OBJECT` ("unseal-keys.json.enc") - The name of the storage object to create containing the unseal keys in the storage bucket specified by `GCS_BUCKET_NAME`
+
 - `KMS_KEY_ID` - The Google Cloud KMS key ID used to encrypt and decrypt the
   vault master key and root token.
 


### PR DESCRIPTION
* Adds the ability to specify file names for root-token and unseal-keys.json storage objects via environment variables. Useful when storing data for multiple clusters in the same bucket.
* Defaults to original hard-coded values for object names to maintain backwards compatibility.
